### PR TITLE
Fix ModuleClientMeta passing row ID instead of module ID

### DIFF
--- a/enhance.php
+++ b/enhance.php
@@ -507,12 +507,12 @@ class Enhance extends Module
             $existing_org_id_obj = $this->ModuleClientMeta->get(
                 $vars['client_id'],
                 'enhance_org_id',
-                $row->id
+                $row->module_id
             );
             $existing_login_id_obj = $this->ModuleClientMeta->get(
                 $vars['client_id'],
                 'enhance_login_id',
-                $row->id
+                $row->module_id
             );
 
             // Extract values from objects (ModuleClientMeta returns objects with ->value property)
@@ -622,7 +622,7 @@ class Enhance extends Module
                 if (!$existing_org_id && $customer_org_id && isset($response['login_id'])) {
                     $this->ModuleClientMeta->set(
                         $vars['client_id'],
-                        $row->id,
+                        $row->module_id,
                         0,
                         [
                             ['key' => 'enhance_org_id', 'value' => $customer_org_id, 'encrypted' => 0],
@@ -1326,7 +1326,7 @@ class Enhance extends Module
                     $existing_login_id_obj = $this->ModuleClientMeta->get(
                         $service->client_id,
                         'enhance_login_id',
-                        $row->id
+                        $row->module_id
                     );
 
                     if (isset($existing_login_id_obj->value)) {
@@ -1415,7 +1415,7 @@ class Enhance extends Module
                     $existing_login_id_obj = $this->ModuleClientMeta->get(
                         $service->client_id,
                         'enhance_login_id',
-                        $row->id
+                        $row->module_id
                     );
 
                     if (isset($existing_login_id_obj->value)) {


### PR DESCRIPTION
When creating a service, the module was always attempting to create a **new customer** in Enhance even when one already existed for the client, resulting in a `409 Login already exists` error from the Enhance API.

`ModuleClientMeta::get()` and `set()` signatures are:

```php
public function get($client_id, $key, $module_id, $module_row_id = 0)
public function set($client_id, $module_id, $module_row_id = 0, array $fields = [])
```

All calls in `enhance.php` were passing `$row->id` as the `module_id` parameter. However, `$row` is the object returned by `getModuleRow()`, which queries the `module_rows` table — so `$row->id` is the **module row primary key**, not the module ID. The correct value is `$row->module_id`.

This mismatch caused `get()` to never find stored customer data, and `set()` to store it under the wrong module ID, making it permanently unfindable.

### Fix

Replaced `$row->id` with `$row->module_id` in all 5 affected instances:

- `addService()` — `ModuleClientMeta->get()` x2 and `ModuleClientMeta->set()` x1
- `tabChangePassword()` — `ModuleClientMeta->get()` x1
- `tabClientChangePassword()` — `ModuleClientMeta->get()` x1

### Note for existing installations

Any records already stored in `module_client_meta` with the wrong `module_id` will need to be corrected manually in the database:

```sql
UPDATE module_client_meta
SET module_id = <correct_module_id>
WHERE `key` IN ('enhance_org_id', 'enhance_login_id');
```
